### PR TITLE
added note that a running prometheus server is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This Python script serves as a Prometheus exporter for Mirth Connect, allowing u
 - Python 3.x
 - `prometheus_client` library (`pip install prometheus_client`)
 - `mirthpy` library (`pip install mirthpy`)
+- A running [Prometheus](https://prometheus.io/) server that scrapes the exporter's metrics endpoint. The exporter only exposes the metrics — a Prometheus server is required to collect and store the data (see `prometheus.yml` for an example scrape configuration).
 
 ## Configuration
 The exporter requires a `mirthConfig.json` file in the same directory with the following structure:


### PR DESCRIPTION
## Summary

This PR updates the README to clarify that a running Prometheus server is
required to actually collect and store the metrics.

## Motivation

The README previously listed only the Python dependencies. New users could
assume the exporter works standalone, when in fact the metrics endpoint is
only useful once a Prometheus server scrapes it.